### PR TITLE
Implement GeoTIFF export functionality with support for passthrough

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@vueuse/core": "^11.0.0",
         "fast-png": "^6.1.0",
         "geotiff": "^2.1.4-beta.1",
+        "jszip": "^3.10.1",
         "leaflet": "^1.9.4",
         "lucide-vue-next": "^0.460.0",
         "proj4": "^2.20.2",
@@ -1508,6 +1509,7 @@
       "resolved": "https://registry.npmjs.org/@tresjs/core/-/core-4.3.6.tgz",
       "integrity": "sha512-CCk4+jwbiTl7Hj3REZqweglUQQdA3cF29TqJ4dEWunaBPyfsAGLTlJExK5lGIS10ptJkr8DqPvHQT41iTIb0Yg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alvarosabu/utils": "^3.2.0",
         "@vue/devtools-api": "^6.6.3",
@@ -1592,6 +1594,7 @@
       "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -2122,6 +2125,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2386,6 +2390,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2670,6 +2675,12 @@
         "he": "bin/he"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -2764,21 +2775,80 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/leaflet": {
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
       "license": "Apache-2.0"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -3107,6 +3177,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3262,6 +3333,12 @@
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
       "dev": true,
       "license": "Unlicense"
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
     },
     "node_modules/proj4": {
       "version": "2.20.2",
@@ -3499,6 +3576,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3512,6 +3595,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.33.5",
@@ -3747,7 +3836,8 @@
       "version": "0.162.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.162.0.tgz",
       "integrity": "sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/three-custom-shader-material": {
       "version": "5.4.0",
@@ -3842,6 +3932,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3883,6 +3974,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3917,6 +4009,7 @@
       "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.1",
@@ -3960,7 +4053,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -3969,6 +4061,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4035,6 +4128,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.25.tgz",
       "integrity": "sha512-YLVdgv2K13WJ6n+kD5owehKtEXwdwXuj2TTyJMsO7pSeKw2bfRNZGjhB7YzrpbMYj5b5QsUebHpOqR3R3ziy/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.25",
         "@vue/compiler-sfc": "3.5.25",
@@ -4087,6 +4181,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@vueuse/core": "^11.0.0",
     "fast-png": "^6.1.0",
     "geotiff": "^2.1.4-beta.1",
+    "jszip": "^3.10.1",
     "leaflet": "^1.9.4",
     "lucide-vue-next": "^0.460.0",
     "proj4": "^2.20.2",

--- a/services/exportGeoTiff.ts
+++ b/services/exportGeoTiff.ts
@@ -1,0 +1,55 @@
+import { writeArrayBuffer } from 'geotiff';
+import JSZip from 'jszip';
+import { TerrainData, LatLng } from '../types';
+import { getGeoTiffCoordsWGS84 } from './geoUtils';
+
+export interface GeoTiffExportResult {
+    blob: Blob;
+    filename: string;
+}
+
+export const exportGeoTiff = async (
+    terrainData: TerrainData,
+    center: LatLng
+): Promise<GeoTiffExportResult> => {
+    const timestamp = new Date().toISOString().slice(0, 19).replace(/:/g, '-');
+    
+    if (terrainData.sourceGeoTiffs) {
+        const { arrayBuffers, source } = terrainData.sourceGeoTiffs;
+        
+        if (arrayBuffers.length === 1) {
+            return {
+                blob: new Blob([arrayBuffers[0]], { type: 'image/tiff' }),
+                filename: `${source.toUpperCase()}_${timestamp}.tif`
+            };
+        } else {
+            const zip = new JSZip();
+            arrayBuffers.forEach((buffer, index) => zip.file(`tile_${index + 1}.tif`, buffer));
+            const zipBlob = await zip.generateAsync({ type: 'blob' });
+            return {
+                blob: zipBlob,
+                filename: `${source.toUpperCase()}_${arrayBuffers.length}tiles_${timestamp}.zip`
+            };
+        }
+    } else {
+        const { width, height, heightMap } = terrainData;
+        const coords = getGeoTiffCoordsWGS84(center.lat, center.lng, width, height);
+
+        const metadata = {
+            height,
+            width,
+            ModelPixelScale: [coords.pixelSizeLng, -coords.pixelSizeLat, 0],
+            ModelTiepoint: [0, 0, 0, coords.topLeftLng, coords.topLeftLat, 0],
+            GeographicTypeGeoKey: 4326,
+            GTModelTypeGeoKey: 2,
+            GTRasterTypeGeoKey: 1
+        };
+
+        const arrayBuffer = await writeArrayBuffer(heightMap, metadata);
+        
+        return {
+            blob: new Blob([arrayBuffer], { type: 'image/tiff' }),
+            filename: `Heightmap_WGS84_${timestamp}.tif`
+        };
+    }
+};

--- a/types.ts
+++ b/types.ts
@@ -31,6 +31,11 @@ export interface TerrainData {
   bounds: Bounds; // Geographic bounds of the generated area
   osmFeatures: OSMFeature[]; // Vector data
   usgsFallback?: boolean; // Flag indicating if USGS data was missing/corrupt and fallback occurred
+  // Raw source GeoTIFF data for passthrough export (preserves original projection)
+  sourceGeoTiffs?: {
+    arrayBuffers: ArrayBuffer[];
+    source: 'gpxz' | 'usgs' | 'global';
+  };
 }
 
 export interface MapState {


### PR DESCRIPTION
This pull request introduces a major refactor and enhancement to the GeoTIFF export functionality, enabling true "passthrough" export of original source GeoTIFF tiles (preserving their projection and metadata) when available, and improving WGS84 export for generated heightmaps. The changes also modularize export logic into a new `exportGeoTiff` service and update the UI to reflect the source of exported data.

**GeoTIFF Export Improvements**

* Added a new `exportGeoTiff` service (`services/exportGeoTiff.ts`) that handles both passthrough export of original source GeoTIFFs (with support for multi-tile zipping) and improved WGS84 export for generated heightmaps. The exported filename now reflects the data source and timestamp.
* Updated the GeoTIFF export button in `ControlPanel.vue` to use the new export service, display the data source (e.g., GPXZ, USGS, or WGS84) in the UI, and set the exported filename accordingly. [[1]](diffhunk://#diff-424a8b3e376452033767160a478ba82c993e34c397539e321d69175dd71f0d4fL309-R309) [[2]](diffhunk://#diff-424a8b3e376452033767160a478ba82c993e34c397539e321d69175dd71f0d4fL722-L758)

**Terrain Data Pipeline Enhancements**

* Modified the terrain data pipeline to capture and propagate raw source GeoTIFF array buffers and their source in the `TerrainData` object, enabling passthrough export. This includes updates to the GPXZ and USGS fetchers to collect the raw ArrayBuffers and changes to `fetchTerrainData` to attach them to the result. [[1]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457L40-R40) [[2]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457L175-R193) [[3]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457R249) [[4]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457R272-R275) [[5]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457L278-R286) [[6]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457R374-R382) [[7]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457L382-R396) [[8]](diffhunk://#diff-cf2a2419a4327551a3f30adc6b02d38840e0e561aa473ee589cf3d04ed31b457L611-R625) [[9]](diffhunk://#diff-8033e9b81c9757b4f6b0dffdbd5f34f7fbc5a59761f876c863768a9da20ea1b7R34-R38)

**GeoTIFF Metadata and Utilities**

* Replaced the old UTM-based GeoTIFF metadata construction with a new utility (`getGeoTiffCoordsWGS84`) for more accurate WGS84 georeferencing, and removed the unused `getGeoKeyDirectory` function. [[1]](diffhunk://#diff-e5dbac7f9ddedbad6b4758af46bf45244c9912a900f7e67e82de2e6ac0aeed27R11-R17) [[2]](diffhunk://#diff-e5dbac7f9ddedbad6b4758af46bf45244c9912a900f7e67e82de2e6ac0aeed27L25-R52)

**Dependency Updates**

* Added the `jszip` library to support zipping multiple GeoTIFF tiles for export.