### PR TITLE
Support for mesh roads instead of road decals

### DIFF
--- a/components/panels/ExportPanel.vue
+++ b/components/panels/ExportPanel.vue
@@ -155,6 +155,14 @@
             </label>
           </div>
 
+          <div class="flex items-center justify-between gap-2 px-0.5">
+            <span class="text-[10px] text-gray-500 dark:text-gray-400 shrink-0">{{ t('exportPanel.roads') }}</span>
+            <label class="flex items-center gap-1.5 cursor-pointer">
+              <input type="checkbox" v-model="beamNGUseMeshRoads" class="rounded border-gray-300 dark:border-gray-600 text-[#FF6600] cursor-pointer" />
+              <span class="text-[9px] text-gray-500 dark:text-gray-400">{{ t('exportPanel.meshRoads') }}</span>
+            </label>
+          </div>
+
           <!-- Export button -->
           <button
             @click="handleBeamNGLevelExport"
@@ -549,6 +557,7 @@ const beamNGApplyFoundations = ref(localStorage.getItem('mapng_beamNGApplyFounda
 const beamNGIncludeWater = ref(localStorage.getItem('mapng_beamNGIncludeWater') !== 'false');
 const beamNGIncludeTrees = ref(localStorage.getItem('mapng_beamNGIncludeTrees') !== 'false');
 const beamNGIncludeRocks = ref(localStorage.getItem('mapng_beamNGIncludeRocks') === 'true');
+const beamNGUseMeshRoads = ref(localStorage.getItem('mapng_beamNGUseMeshRoads') === 'true');
 const beamNGTreeDensity = ref(Math.max(0.5, Math.min(10, Number(localStorage.getItem('mapng_beamNGTreeDensity') || '1') || 1)));
 const beamNGFlavorOptions = getBeamNGFlavorOptions();
 const persistedBeamNGFlavor = localStorage.getItem('mapng_beamNGFlavorId') || '';
@@ -599,6 +608,7 @@ watch(beamNGApplyFoundations, (v) => localStorage.setItem('mapng_beamNGApplyFoun
 watch(beamNGIncludeWater, (v) => localStorage.setItem('mapng_beamNGIncludeWater', String(v)));
 watch(beamNGIncludeTrees, (v) => localStorage.setItem('mapng_beamNGIncludeTrees', String(v)));
 watch(beamNGIncludeRocks, (v) => localStorage.setItem('mapng_beamNGIncludeRocks', String(v)));
+watch(beamNGUseMeshRoads, (v) => localStorage.setItem('mapng_beamNGUseMeshRoads', String(v)));
 watch(beamNGTreeDensity, (v) => localStorage.setItem('mapng_beamNGTreeDensity', String(v)));
 watch(beamNGFlavorId, (v) => localStorage.setItem('mapng_beamNGFlavorId', v));
 watch(showExportGeo, (v) => localStorage.setItem('mapng_showExportGeo', String(v)));
@@ -1187,6 +1197,7 @@ const handleBeamNGLevelExport = async () => {
       includeWater: beamNGIncludeWater.value,
       includeTrees: beamNGIncludeTrees.value,
       includeRocks: beamNGIncludeRocks.value,
+      useMeshRoads: beamNGUseMeshRoads.value,
       treeDensity: beamNGTreeDensity.value,
       flavorId: beamNGFlavorId.value,
       levelName: beamNGLevelName.value.trim(),

--- a/locales/de.json
+++ b/locales/de.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Experimentell über 5x: sehr dichte Wälder können Exportzeit und Speicherverbrauch erhöhen.",
     "rocks": "Felsen",
     "quarryRock": "Steinbruch-/Felsdeckung",
+    "roads": "Straßen",
+    "meshRoads": "3D-Netzgeometrie",
     "beamngLevelExport": "BeamNG-Level-Export",
     "generatePlayableZip": "Spielbares .zip-Paket erzeugen",
     "assets2d": "2D-Assets",

--- a/locales/en.json
+++ b/locales/en.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Experimental above 5x: very dense forests can increase export time and memory usage.",
     "rocks": "Rocks",
     "quarryRock": "Quarry/rock cover",
+    "roads": "Roads",
+    "meshRoads": "3D mesh geometry",
     "beamngLevelExport": "BeamNG Level Export",
     "generatePlayableZip": "Generate playable .zip package",
     "assets2d": "2D Assets",

--- a/locales/es.json
+++ b/locales/es.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Experimental por encima de 5x: bosques muy densos pueden aumentar tiempo y memoria.",
     "rocks": "Rocas",
     "quarryRock": "Cobertura de cantera/roca",
+    "roads": "Calles",
+    "meshRoads": "Geometría malla 3D",
     "beamngLevelExport": "Exportacion de nivel BeamNG",
     "generatePlayableZip": "Generar paquete .zip jugable",
     "assets2d": "Assets 2D",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Experimental au-dessus de 5x : des forets tres denses peuvent augmenter le temps d'export et l'utilisation memoire.",
     "rocks": "Rochers",
     "quarryRock": "Carriere/couverture rocheuse",
+    "roads": "Routes",
+    "meshRoads": "Géométrie maillée 3D",
     "beamngLevelExport": "Export de niveau BeamNG",
     "generatePlayableZip": "Generer un package .zip jouable",
     "assets2d": "Ressources 2D",

--- a/locales/it.json
+++ b/locales/it.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Sperimentale sopra 5x: le foreste molto dense possono aumentare il tempo di esportazione e l'uso della memoria.",
     "rocks": "Rocce",
     "quarryRock": "Copertura cava/roccia",
+    "roads": "Strade",
+    "meshRoads": "Geometria mesh 3D",
     "beamngLevelExport": "Esportazione Livello BeamNG",
     "generatePlayableZip": "Genera pacchetto .zip giocabile",
     "assets2d": "Asset 2D",

--- a/locales/pl.json
+++ b/locales/pl.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Eksperymentalne powyżej 5x: bardzo gęste lasy mogą zwiększyć czas eksportu i użycie pamięci.",
     "rocks": "Skały",
     "quarryRock": "Kwatera/pokrycie skalne",
+    "roads": "Drogi",
+    "meshRoads": "Geometria siatki 3D",
     "beamngLevelExport": "Eksport poziomu BeamNG",
     "generatePlayableZip": "Wygeneruj pakiet .zip do gry",
     "assets2d": "Zasoby 2D",

--- a/locales/ru.json
+++ b/locales/ru.json
@@ -252,6 +252,8 @@
     "experimentalTreeDensity": "Экспериментально выше 5x: очень плотные леса могут увеличить время экспорта и расход памяти.",
     "rocks": "Камни",
     "quarryRock": "Покрытие карьера/камней",
+    "roads": "Дороги",
+    "meshRoads": "3D-геометрия меша",
     "beamngLevelExport": "Экспорт уровня BeamNG",
     "generatePlayableZip": "Сгенерировать играбельный .zip",
     "assets2d": "2D ассеты",

--- a/services/exportBeamNGLevel.js
+++ b/services/exportBeamNGLevel.js
@@ -1024,7 +1024,7 @@ function generateMeshRoads(terrainData, squareSize) {
         rawNodes.push([
           Math.round(wx * 1000) / 1000,
           Math.round(wy * 1000) / 1000,
-          Math.round((wz + 1) * 1000) / 1000,
+          Math.round((wz + 0.5) * 1000) / 1000,
           fullWidth,
           4,
           0, 0, 1,

--- a/services/exportBeamNGLevel.js
+++ b/services/exportBeamNGLevel.js
@@ -987,6 +987,77 @@ function generateDecalRoads(terrainData, squareSize) {
 }
 
 /**
+ * Convert OSM road features to BeamNG MeshRoad 3D geometry objects.
+ *
+ * Each road segment becomes a MeshRoad with m_asphalt_new_01 on the top, side,
+ * and bottom surfaces. Node format is [x, y, z, fullWidth, depth, nx, ny, nz].
+ * Roads that were split by clipping or chunking share an incremented counter
+ * so each object gets a unique name.
+ *
+ * Returns an empty array when no OSM data is available or useMeshRoads is false.
+ */
+function generateMeshRoads(terrainData, squareSize) {
+  if (!terrainData.osmFeatures?.length) return [];
+
+  const meshRoads = [];
+  let roadIndex = 0;
+
+  for (const feature of terrainData.osmFeatures) {
+    if (feature.type !== 'road' || !feature.geometry?.length) continue;
+
+    const highway = feature.tags?.highway;
+    if (!highway || ROAD_SKIP.has(highway)) continue;
+
+    const style = HIGHWAY_STYLE[highway] ?? DEFAULT_ROAD_STYLE;
+    const isOneWay = isOneWayRoad(feature.tags || {});
+    const halfWidth = estimateRoadHalfWidth(feature.tags || {}, highway, isOneWay, style.width);
+    const fullWidth = halfWidth * 2;
+
+    const clippedSegments = clipGeometryToMargin(feature.geometry, terrainData.bounds)
+      .flatMap(s => chunkPolyline(s));
+
+    for (const segment of clippedSegments) {
+      const rawNodes = [];
+      for (const pt of segment) {
+        const [wx, wy, wz] = geoToWorld(pt.lat, pt.lng, terrainData, squareSize, 0.1);
+        // MeshRoad node: [x, y, z, fullWidth, depth, normalX, normalY, normalZ]
+        rawNodes.push([
+          Math.round(wx * 1000) / 1000,
+          Math.round(wy * 1000) / 1000,
+          Math.round((wz + 1) * 1000) / 1000,
+          fullWidth,
+          4,
+          0, 0, 1,
+        ]);
+      }
+
+      // Reuse decimation but strip/re-add the extra fields (decimateNodes works on [x,y,z,w])
+      const stripped = rawNodes.map(n => [n[0], n[1], n[2], n[3]]);
+      const decimated = decimateNodes(stripped);
+      if (decimated.length < 2) continue;
+
+      // Reattach depth and normal after decimation
+      const nodes = decimated.map(n => [n[0], n[1], n[2], n[3], 0.5, 0, 0, 1]);
+
+      meshRoads.push({
+        class: 'MeshRoad',
+        name: `MeshRoad_${roadIndex++}`,
+        persistentId: generatePersistentId(),
+        __parent: 'Mesh_roads',
+        position: [nodes[0][0], nodes[0][1], nodes[0][2]],
+        topMaterial: 'm_asphalt_new_01',
+        sideMaterial: 'm_asphalt_new_01',
+        bottomMaterial: 'm_asphalt_new_01',
+        textureLength: 16,
+        nodes,
+      });
+    }
+  }
+
+  return meshRoads;
+}
+
+/**
  * Write a newline-delimited JSON (NDJSON) string from an array of objects.
  * Each object is one line, file ends with a newline — matching BeamNG's format.
  */
@@ -2024,6 +2095,7 @@ function buildGroundCoverObjects(terrainData, squareSize, includeTrees, flavor) 
  * @param {'osm'|'image'|'none'} [options.pbrSource='osm'] — layer map source: 'osm' uses OSM polygon data,
  *   'image' infers materials from the segmented hybrid satellite image, 'none' disables PBR materials.
  *   Legacy boolean option `generatePbrMaterials` is still accepted for backward compatibility.
+ * @param {boolean} [options.useMeshRoads=false]            — export roads as 3D MeshRoad geometry instead of flat DecalRoad decals
  */
 export async function exportBeamNGLevel(terrainData, center, options = {}) {
   const {
@@ -2035,6 +2107,7 @@ export async function exportBeamNGLevel(terrainData, center, options = {}) {
     includeTrees = true,
     includeRocks = false,
     treeDensity = 1,
+    useMeshRoads = false,
     flavorId,
     levelName: requestedLevelName = '',
     onProgress,
@@ -2137,7 +2210,8 @@ export async function exportBeamNGLevel(terrainData, center, options = {}) {
   const { position: spawnPosition, rotationMatrix: spawnRotationMatrix } =
     findSpawnPosition(exportTerrainData, center, squareSize);
 
-  const decalRoads = generateDecalRoads(exportTerrainData, squareSize);
+  const decalRoads = useMeshRoads ? [] : generateDecalRoads(exportTerrainData, squareSize);
+  const meshRoads = useMeshRoads ? generateMeshRoads(exportTerrainData, squareSize) : [];
 
   // ── Sequential pipeline — one heavy operation at a time ────────────────────
   // Running everything in parallel (Promise.all) keeps multiple large buffers
@@ -2501,12 +2575,21 @@ export async function exportBeamNGLevel(terrainData, center, options = {}) {
   if (decalRoads.length > 0) {
     missionGroupItems.push({ __parent: 'MissionGroup', class: 'SimGroup', name: 'Decal_roads', persistentId: generatePersistentId() });
   }
+  if (meshRoads.length > 0) {
+    missionGroupItems.push({ __parent: 'MissionGroup', class: 'SimGroup', name: 'Mesh_roads', persistentId: generatePersistentId() });
+  }
   zip.file(`${base}/main/MissionGroup/items.level.json`, toNDJSON(missionGroupItems));
 
   // ── main/MissionGroup/Decal_roads/items.level.json ─────────────────────────
   if (decalRoads.length > 0) {
     zip.folder(`${base}/main/MissionGroup/Decal_roads`);
     zip.file(`${base}/main/MissionGroup/Decal_roads/items.level.json`, toNDJSON(decalRoads));
+  }
+
+  // ── main/MissionGroup/Mesh_roads/items.level.json ──────────────────────────
+  if (meshRoads.length > 0) {
+    zip.folder(`${base}/main/MissionGroup/Mesh_roads`);
+    zip.file(`${base}/main/MissionGroup/Mesh_roads/items.level.json`, toNDJSON(meshRoads));
   }
 
   // ── main/MissionGroup/Level_objects/items.level.json ──────────────────────


### PR DESCRIPTION
PS Thank you so much for creating this amazing project :) 

**Features**
- Toggle in ui for switching between decals and mesh roads
- Uses the same width and positioning logic as decals 
- Handles underpasses + overpasses surprisingly well (Although some still need manual tweaking)

**Current limitations**
- All roads are the same depth/height, ideally they should adjust based on the type of road.
- Has a tendency to create sharp road edges that deflate tires when multiple overlapping roads with ever-so-slightly varying z-elevation data are generated. I will most likely address this via some sort of averaging or smoothing for nearby or overlapping or junction nodes
- Sometimes terrain can clip above the road when two road mesh nodes are far enough apart while the terrain data is more granular. I plan on fixing this by clamping the z-pos to terrain
- Doesn't currently support lane markings
- Doesn't have mapped textures for flavors like your decal implementation. (Feel free to add)
- Translation strings are LLM generated no idea if they're correct in non-english languages 🤷 