### PR TITLE
Only show region-specific elevation sources when area selection is within bounds of region

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -26,6 +26,7 @@
       <ControlPanel
         v-if="!batchMode"
         :center="center"
+        :center-stable="centerStable"
         :zoom="zoom"
         :resolution="resolution"
         :dev-mode="devMode"
@@ -58,6 +59,7 @@
       <BatchControlPanel
         v-if="batchMode"
         :center="center"
+        :center-stable="centerStable"
         :resolution="resolution"
         :processing-meters-per-pixel="processingMetersPerPixel"
         :is-running="batchRunning"
@@ -106,7 +108,7 @@
             :surrounding-tile-positions="surroundingTilePositions"
             :batch-grid="batchGridTiles"
             :batch-editable="batchMode && !batchRunning && !showBatchProgress"
-            @move="handleMapMove" 
+            @moveend="handleMapMoveEnd"
             @zoom="store.setZoom"
             @batch-tile-drag="handleBatchTileDrag"
           />
@@ -240,6 +242,7 @@ const store = useMainStore();
 const { t } = useI18n({ useScope: 'global' });
 const {
   center,
+  centerStable,
   zoom,
   resolution,
   isDarkMode,
@@ -407,7 +410,7 @@ const buildMainTime = formatBuildTime(__BUILD_MAIN_TIME__);
 const buildDevHash = String(__BUILD_DEV_HASH__ || 'n/a');
 const buildDevTime = formatBuildTime(__BUILD_DEV_TIME__);
 
-const { setCenter, setResolution, setBatchMode: setStoreBatchMode } = store;
+const { setCenter, setCenterStable, setResolution, setBatchMode: setStoreBatchMode } = store;
 
 const isValidCenter = (point) => {
   const lat = Number(point?.lat);
@@ -456,6 +459,7 @@ onUnmounted(() => {
 
 const handleLocationChange = (newCenter) => {
   setCenter(newCenter);
+  setCenterStable(newCenter);
   terrainData.value = null;
   lastGenerationKey.value = null;
   // Cancel any in-flight generation when location changes
@@ -986,9 +990,10 @@ const handleBatchTileDrag = ({ index, lat, lng }) => {
   store.setBatchTileOffsets(next);
 };
 
-const handleMapMove = (newCenter) => {
+const handleMapMoveEnd = (newCenter) => {
   const oldCenter = center.value;
   store.setCenter(newCenter);
+  setCenterStable(newCenter);
 
   // "World-fixed" mode: when the user pans the map, keep the batch tiles
   // anchored at their geographic positions instead of moving with the grid

--- a/App.vue
+++ b/App.vue
@@ -108,6 +108,7 @@
             :surrounding-tile-positions="surroundingTilePositions"
             :batch-grid="batchGridTiles"
             :batch-editable="batchMode && !batchRunning && !showBatchProgress"
+            @move="handleMapMove"
             @moveend="handleMapMoveEnd"
             @zoom="store.setZoom"
             @batch-tile-drag="handleBatchTileDrag"
@@ -988,6 +989,10 @@ const handleBatchTileDrag = ({ index, lat, lng }) => {
     .sort((a, b) => a.index - b.index);
 
   store.setBatchTileOffsets(next);
+};
+
+const handleMapMove = (newCenter) => {
+  store.setLiveCenter(newCenter);
 };
 
 const handleMapMoveEnd = (newCenter) => {

--- a/components/map/CoordinatesInput.vue
+++ b/components/map/CoordinatesInput.vue
@@ -34,6 +34,9 @@ import { ref, watch, nextTick } from 'vue';
 import { useI18n } from 'vue-i18n';
 import LocationSearch from './LocationSearch.vue';
 import { SELECT_SM } from '../base/controlStyles.js';
+import { useMainStore } from '../../stores/mainStore';
+
+const store = useMainStore();
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -135,6 +138,16 @@ const handleLocationSelect = (event) => {
 };
 
 watch(() => props.center, (newVal) => {
+  if (parseFloat(latInput.value) !== newVal.lat) {
+    latInput.value = newVal.lat.toString();
+  }
+  if (parseFloat(lngInput.value) !== newVal.lng) {
+    lngInput.value = newVal.lng.toString();
+  }
+}, { deep: true });
+
+watch(() => store.liveCenter, (newVal) => {
+  if (!newVal) return;
   if (parseFloat(latInput.value) !== newVal.lat) {
     latInput.value = newVal.lat.toString();
   }

--- a/components/map/ElevationSourceSelector.vue
+++ b/components/map/ElevationSourceSelector.vue
@@ -12,115 +12,81 @@
     </button>
     
     <div v-if="showElevationSource" class="space-y-2 bg-gray-50 dark:bg-gray-700 p-2 rounded border border-gray-200 dark:border-gray-600">
-        <!-- Default -->
-        <label class="flex items-start gap-2 cursor-pointer p-1 hover:bg-gray-100 dark:hover:bg-gray-600 rounded transition-colors">
-            <input type="radio" v-model="localElevationSource" value="default" class="mt-0.5 accent-[#FF6600]" />
-            <div class="space-y-0.5">
-              <span class="block text-xs font-medium text-gray-900 dark:text-white">{{ t('map.standard30m') }}</span>
-                <span class="block text-[10px] text-gray-500 dark:text-gray-400 leading-tight">
-                {{ t('map.standardDescription') }}
-                </span>
-            </div>
-        </label>
-
-        <!-- None / Flat -->
-        <label class="flex items-start gap-2 cursor-pointer p-1 hover:bg-gray-100 dark:hover:bg-gray-600 rounded transition-colors">
-            <input type="radio" v-model="localElevationSource" value="none" class="mt-0.5 accent-[#FF6600]" />
-            <div class="space-y-0.5">
-              <span class="block text-xs font-medium text-gray-900 dark:text-white">{{ t('map.flatNone') }}</span>
-                <span class="block text-[10px] text-gray-500 dark:text-gray-400 leading-tight">
-                {{ t('map.flatNoneDescription') }}
-                </span>
-            </div>
-        </label>
-
-        <!-- NMT EVRF2007 -->
-        <label class="flex items-start gap-2 cursor-pointer p-1 hover:bg-gray-100 dark:hover:bg-gray-600 rounded transition-colors">
-          <input type="radio" v-model="localElevationSource" value="kron86" class="mt-0.5 accent-[#FF6600]" />
-          <div class="space-y-0.5">
-            <span class="block text-xs font-medium text-gray-900 dark:text-white">{{ t('map.kron86Poland') }}</span>
-            <span class="block text-[10px] text-gray-500 dark:text-gray-400 leading-tight">
-            {{ t('map.kron86Description') }}
-            </span>
-          </div>
-        </label>
-
-        <!-- USGS -->
-        <label class="flex items-start gap-2 cursor-pointer p-1 hover:bg-gray-100 dark:hover:bg-gray-600 rounded transition-colors">
-            <input type="radio" v-model="localElevationSource" value="usgs" class="mt-0.5 accent-[#FF6600]" />
-            <div class="space-y-0.5">
-                <div class="flex items-center gap-2">
-                <span class="block text-xs font-medium text-gray-900 dark:text-white">{{ t('map.usgs1m') }}</span>
-                <span v-if="usgsStatus" class="text-[9px] text-emerald-600 dark:text-emerald-400 font-bold px-1 bg-emerald-100 dark:bg-emerald-900/30 rounded">{{ t('map.online') }}</span>
-                <span v-else-if="usgsStatus === false" class="text-[9px] text-red-600 dark:text-red-400 font-bold px-1 bg-red-100 dark:bg-red-900/30 rounded">{{ t('map.offline') }}</span>
-                </div>
-                <span class="block text-[10px] text-gray-500 dark:text-gray-400 leading-tight">
-                {{ t('map.usgsDescription') }}
-                </span>
-            </div>
-        </label>
-
-        <!-- GPXZ -->
-        <label class="flex items-start gap-2 cursor-pointer p-1 hover:bg-gray-100 dark:hover:bg-gray-600 rounded transition-colors">
-            <input type="radio" v-model="localElevationSource" value="gpxz" class="mt-0.5 accent-[#FF6600]" />
-            <div class="space-y-0.5 w-full">
-                <span class="block text-xs font-medium text-gray-900 dark:text-white">{{ t('map.gpxzPremium') }}</span>
-                <span class="block text-[10px] text-gray-500 dark:text-gray-400 leading-tight">
-                    {{ t('map.gpxzDescription') }} <a href="https://www.gpxz.io/docs/dataset#coverage" target="_blank" class="text-[#FF6600] hover:underline" @click.stop>{{ t('map.checkCoverage') }}</a>
-                </span>
-                
-                <div v-if="localElevationSource === 'gpxz'" class="mt-2 animate-in fade-in slide-in-from-top-1">
-                    <input 
-                        type="password" 
-                        v-model="localGpxzApiKey"
-                        :placeholder="t('map.enterGpxzKey')"
-                        class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs text-gray-900 dark:text-white focus:ring-1 focus:ring-[#FF6600] outline-none"
-                    />
-                    <p class="text-[10px] text-gray-500 dark:text-gray-400 leading-tight mt-1">
-                        {{ t('map.freeTier') }} <a href="https://www.gpxz.io/" target="_blank" class="text-[#FF6600] hover:underline">{{ t('map.getKey') }}</a>
-                    </p>
-                    <p v-if="isBatchMode" class="text-[10px] text-amber-600 dark:text-amber-500 font-medium mt-1">
-                      ⚠️ {{ t('map.gpxzBatchWarning', { tiles: totalTiles }) }}
-                    </p>
-                    <!-- GPXZ Account Status -->
-                    <div v-if="localGpxzApiKey" class="mt-2">
-                      <button @click="verifyGpxzKey" :disabled="isCheckingGPXZ"
-                        class="text-[10px] text-[#FF6600] hover:underline disabled:opacity-50 disabled:no-underline">
-                        {{ isCheckingGPXZ ? t('map.checking') : (gpxzStatus ? t('map.refreshStatus') : t('map.checkAccount')) }}
-                      </button>
-                      <div v-if="gpxzStatus" class="mt-1 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-600 p-2 space-y-1">
-                        <div class="flex items-center justify-between text-[10px]">
-                          <span class="text-gray-500 dark:text-gray-400">{{ t('map.plan') }}</span>
-                          <span :class="['font-bold uppercase', gpxzStatus.plan === 'free' ? 'text-gray-600 dark:text-gray-300' : 'text-emerald-600 dark:text-emerald-400']">{{ gpxzStatus.plan }}</span>
-                        </div>
-                        <div class="flex items-center justify-between text-[10px]">
-                          <span class="text-gray-500 dark:text-gray-400">{{ t('map.today') }}</span>
-                          <span class="text-gray-700 dark:text-gray-300">{{ gpxzStatus.used }} / {{ gpxzStatus.limit }}</span>
-                        </div>
-                        <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1 mt-0.5">
-                          <div class="h-1 rounded-full transition-all" :class="gpxzStatus.remaining < 20 ? 'bg-red-500' : 'bg-emerald-500'" :style="{ width: Math.min(100, (gpxzStatus.used / gpxzStatus.limit) * 100) + '%' }"></div>
-                        </div>
-                        <div class="flex items-center justify-between text-[10px]">
-                          <span class="text-gray-500 dark:text-gray-400">{{ t('map.concurrency') }}</span>
-                          <span class="text-gray-700 dark:text-gray-300">{{ t('map.parallel', { count: gpxzStatus.concurrency }) }}</span>
-                        </div>
-                        <p v-if="!gpxzStatus.valid" class="text-[10px] text-red-500 font-medium">⚠️ {{ t('map.invalidApiKey') }}</p>
-                      </div>
+        <template v-for="source in availableSources" :key="source.id">
+            <label class="flex items-start gap-2 cursor-pointer p-1 hover:bg-gray-100 dark:hover:bg-gray-600 rounded transition-colors">
+                <input type="radio" v-model="localElevationSource" :value="source.id" class="mt-0.5 accent-[#FF6600]" />
+                <div class="space-y-0.5 w-full">
+                    <div class="flex items-center gap-2">
+                        <span class="block text-xs font-medium text-gray-900 dark:text-white">{{ t(source.labelKey) }}</span>
+                        <!-- Custom USGS Status Pill -->
+                        <template v-if="source.id === 'usgs'">
+                            <span v-if="usgsStatus" class="text-[9px] text-emerald-600 dark:text-emerald-400 font-bold px-1 bg-emerald-100 dark:bg-emerald-900/30 rounded">{{ t('map.online') }}</span>
+                            <span v-else-if="usgsStatus === false" class="text-[9px] text-red-600 dark:text-red-400 font-bold px-1 bg-red-100 dark:bg-red-900/30 rounded">{{ t('map.offline') }}</span>
+                        </template>
                     </div>
-                    <p v-if="isAreaLargeForGPXZ" class="text-[10px] text-orange-600 dark:text-orange-400 font-medium leading-tight mt-1">
-                        ⚠️ {{ t('map.largeAreaWarning', { area: areaSqKm.toFixed(2) }) }}
-                    </p>
+                    <span class="block text-[10px] text-gray-500 dark:text-gray-400 leading-tight">
+                        {{ t(source.descriptionKey) }}
+                        <!-- Custom GPXZ Link -->
+                        <template v-if="source.id === 'gpxz'">
+                            <a href="https://www.gpxz.io/docs/dataset#coverage" target="_blank" class="text-[#FF6600] hover:underline" @click.stop>{{ t('map.checkCoverage') }}</a>
+                        </template>
+                    </span>
+                    
+                    <!-- Custom GPXZ settings panel -->
+                    <div v-if="source.id === 'gpxz' && localElevationSource === 'gpxz'" class="mt-2 animate-in fade-in slide-in-from-top-1">
+                        <input 
+                            type="password" 
+                            v-model="localGpxzApiKey"
+                            :placeholder="t('map.enterGpxzKey')"
+                            class="w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded px-2 py-1 text-xs text-gray-900 dark:text-white focus:ring-1 focus:ring-[#FF6600] outline-none"
+                        />
+                        <p class="text-[10px] text-gray-500 dark:text-gray-400 leading-tight mt-1">
+                            {{ t('map.freeTier') }} <a href="https://www.gpxz.io/" target="_blank" class="text-[#FF6600] hover:underline">{{ t('map.getKey') }}</a>
+                        </p>
+                        <p v-if="isBatchMode" class="text-[10px] text-amber-600 dark:text-amber-500 font-medium mt-1">
+                          ⚠️ {{ t('map.gpxzBatchWarning', { tiles: totalTiles }) }}
+                        </p>
+                        <!-- GPXZ Account Status -->
+                        <div v-if="localGpxzApiKey" class="mt-2">
+                          <button @click="verifyGpxzKey" :disabled="isCheckingGPXZ"
+                            class="text-[10px] text-[#FF6600] hover:underline disabled:opacity-50 disabled:no-underline">
+                            {{ isCheckingGPXZ ? t('map.checking') : (gpxzStatus ? t('map.refreshStatus') : t('map.checkAccount')) }}
+                          </button>
+                          <div v-if="gpxzStatus" class="mt-1 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-600 p-2 space-y-1">
+                            <div class="flex items-center justify-between text-[10px]">
+                              <span class="text-gray-500 dark:text-gray-400">{{ t('map.plan') }}</span>
+                              <span :class="['font-bold uppercase', gpxzStatus.plan === 'free' ? 'text-gray-600 dark:text-gray-300' : 'text-emerald-600 dark:text-emerald-400']">{{ gpxzStatus.plan }}</span>
+                            </div>
+                            <div class="flex items-center justify-between text-[10px]">
+                              <span class="text-gray-500 dark:text-gray-400">{{ t('map.today') }}</span>
+                              <span class="text-gray-700 dark:text-gray-300">{{ gpxzStatus.used }} / {{ gpxzStatus.limit }}</span>
+                            </div>
+                            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-1 mt-0.5">
+                              <div class="h-1 rounded-full transition-all" :class="gpxzStatus.remaining < 20 ? 'bg-red-500' : 'bg-emerald-500'" :style="{ width: Math.min(100, (gpxzStatus.used / gpxzStatus.limit) * 100) + '%' }"></div>
+                            </div>
+                            <div class="flex items-center justify-between text-[10px]">
+                              <span class="text-gray-500 dark:text-gray-400">{{ t('map.concurrency') }}</span>
+                              <span class="text-gray-700 dark:text-gray-300">{{ t('map.parallel', { count: gpxzStatus.concurrency }) }}</span>
+                            </div>
+                            <p v-if="!gpxzStatus.valid" class="text-[10px] text-red-500 font-medium">⚠️ {{ t('map.invalidApiKey') }}</p>
+                          </div>
+                        </div>
+                        <p v-if="isAreaLargeForGPXZ" class="text-[10px] text-orange-600 dark:text-orange-400 font-medium leading-tight mt-1">
+                            ⚠️ {{ t('map.largeAreaWarning', { area: areaSqKm.toFixed(2) }) }}
+                        </p>
+                    </div>
                 </div>
-            </div>
-        </label>
+            </label>
+        </template>
     </div>
   </div>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, computed, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { Mountain, ChevronDown } from 'lucide-vue-next';
+import { ELEVATION_SOURCES } from '../../services/elevationSources.js';
 
 const { t } = useI18n({ useScope: 'global' });
 
@@ -160,6 +126,10 @@ const props = defineProps({
   totalTiles: {
     type: Number,
     default: 0
+  },
+  center: {
+    type: Object,
+    default: null
   }
 });
 
@@ -168,6 +138,13 @@ const emit = defineEmits(['update:elevationSource', 'update:gpxzApiKey', 'verify
 const localElevationSource = ref(props.elevationSource);
 const localGpxzApiKey = ref(props.gpxzApiKey);
 const showElevationSource = ref(localStorage.getItem('mapng_showElevationSource') === 'true');
+
+const availableSources = computed(() => {
+  return ELEVATION_SOURCES.filter((source) => {
+    if (source.isGlobal || !source.checkCoverage) return true;
+    return source.checkCoverage(props.center);
+  });
+});
 
 watch(showElevationSource, (v) => localStorage.setItem('mapng_showElevationSource', String(v)));
 

--- a/components/map/MapSelector.vue
+++ b/components/map/MapSelector.vue
@@ -7,6 +7,7 @@
         :options="mapOptions"
         style="height: 100%; width: 100%"
         @move="handleMove"
+        @moveend="handleMoveEnd"
         @zoom="handleZoom"
      >
       <!-- Base Layers -->
@@ -236,7 +237,7 @@ const batchTileFillOpacity = (tile) => {
   }
 };
 
-const emit = defineEmits(['move', 'zoom', 'batchTileDrag']);
+const emit = defineEmits(['move', 'moveend', 'zoom', 'batchTileDrag']);
 
 const mapRef = ref(null);
 const currentCenter = ref(props.center);
@@ -396,6 +397,16 @@ const handleMove = () => {
 
   currentCenter.value = { lat: c.lat, lng: normalizedLng };
   emit('move', currentCenter.value);
+};
+
+const handleMoveEnd = () => {
+  if (isMovingProgrammatically.value) return;
+  if (!mapRef.value?.leafletObject) return;
+  const map = mapRef.value.leafletObject;
+  const c = map.getCenter();
+  const normalizedLng = normalizeDatelineLongitude(c.lng);
+  currentCenter.value = { lat: c.lat, lng: normalizedLng };
+  emit('moveend', currentCenter.value);
 };
 
 // Handle map zoom

--- a/components/panels/BatchControlPanel.vue
+++ b/components/panels/BatchControlPanel.vue
@@ -198,6 +198,7 @@
       :isCheckingGPXZ="isCheckingGPXZ"
       :isBatchMode="true"
       :totalTiles="totalTiles"
+      :center="centerStable"
       @verifyGpxzKey="checkGPXZStatus"
     />
 
@@ -326,11 +327,13 @@ import ProcessingResolutionInput from '../controls/ProcessingResolutionInput.vue
 import BaseButton from '../base/BaseButton.vue';
 import { probeGPXZLimits } from '../../services/terrain';
 import { cloneRateLimitInfo, downloadJsonFile } from '../../services/traceability';
+import { ELEVATION_SOURCES } from '../../services/elevationSources.js';
 
 const { t } = useI18n({ useScope: 'global' });
 
 const props = defineProps({
   center: { type: Object, required: true },
+  centerStable: { type: Object, required: true },
   resolution: { type: Number, required: true },
   processingMetersPerPixel: { type: [Number, String], default: 1 },
   isRunning: { type: Boolean, default: false },
@@ -995,6 +998,16 @@ const checkGPXZStatus = async () => {
     isCheckingGPXZ.value = false;
   }
 };
+
+watch(() => props.centerStable, (newCenter) => {
+  if (!newCenter) return;
+  const currentSource = ELEVATION_SOURCES.find(s => s.id === elevationSource.value);
+  if (currentSource && !currentSource.isGlobal && currentSource.checkCoverage) {
+    if (!currentSource.checkCoverage(newCenter)) {
+      elevationSource.value = 'default';
+    }
+  }
+}, { immediate: true, deep: true });
 watch(meshResolution, (v) => localStorage.setItem('mapng_batch_mesh', String(v)));
 watch(performanceProfile, (v) => localStorage.setItem('mapng_batch_profile', v));
 watch(exports, (v) => localStorage.setItem('mapng_batch_exports', JSON.stringify(normalizeExports(v))), {

--- a/components/panels/ControlPanel.vue
+++ b/components/panels/ControlPanel.vue
@@ -165,6 +165,7 @@
         :isCheckingGPXZ="isCheckingGPXZ"
         :isAreaLargeForGPXZ="isAreaLargeForGPXZ"
         :areaSqKm="areaSqKm"
+        :center="centerStable"
         @verifyGpxzKey="checkGPXZStatus"
       />
     </div>
@@ -293,10 +294,11 @@ import { downloadJsonFile } from '../../services/traceability';
 import { exportJobData, importJobData } from '../../services/jobData';
 import { buildRunConfiguration as buildRunConfigurationBase } from '../../services/runConfiguration';
 import { getMaxSquareCropResolution, scaleNativeDimsToProcessingMpp } from '../../services/uploadBounds';
+import { ELEVATION_SOURCES } from '../../services/elevationSources.js';
 
 const { t } = useI18n({ useScope: 'global' });
 
-const props = defineProps(['center', 'zoom', 'resolution', 'devMode', 'isGenerating', 'terrainData', 'generationCacheKey', 'uploadedElevationFile', 'uploadedElevationMeta', 'uploadedAscCoordinateSystem', 'uploadedAreaMode', 'processingMetersPerPixel']);
+const props = defineProps(['center', 'centerStable', 'zoom', 'resolution', 'devMode', 'isGenerating', 'terrainData', 'generationCacheKey', 'uploadedElevationFile', 'uploadedElevationMeta', 'uploadedAscCoordinateSystem', 'uploadedAreaMode', 'processingMetersPerPixel']);
 
 const emit = defineEmits(['locationChange', 'resolutionChange', 'zoomChange', 'generate', 'fetchOsm', 'surroundingTilesChange', 'importData', 'elevationFileSelected', 'elevationFileClear', 'showSupport', 'exportSuccess', 'update:uploadedAscCoordinateSystem', 'update:uploadedAreaMode', 'update:processingMetersPerPixel', 'update:previewStale']);
 
@@ -423,6 +425,16 @@ const checkGPXZStatus = async () => {
     isCheckingGPXZ.value = false;
   }
 };
+
+watch(() => props.centerStable, (newCenter) => {
+  if (!newCenter) return;
+  const currentSource = ELEVATION_SOURCES.find(s => s.id === elevationSource.value);
+  if (currentSource && !currentSource.isGlobal && currentSource.checkCoverage) {
+    if (!currentSource.checkCoverage(newCenter)) {
+      elevationSource.value = 'default';
+    }
+  }
+}, { immediate: true, deep: true });
 
 // Persist collapsible section states
 watch(showCoordinates, (v) => localStorage.setItem('mapng_showCoordinates', String(v)));

--- a/services/elevationSources.js
+++ b/services/elevationSources.js
@@ -1,0 +1,77 @@
+export const KRON86_POLAND_BOUNDS = {
+  west: 13.70,
+  south: 48.64,
+  east: 24.87,
+  north: 55.03,
+};
+
+export const USGS_CONUS_BOUNDS = {
+  west: -125,
+  south: 24,
+  east: -66,
+  north: 50,
+};
+
+export const USGS_ALASKA_BOUNDS = {
+  west: -170,
+  south: 50,
+  east: -129,
+  north: 72,
+};
+
+export const USGS_HAWAII_BOUNDS = {
+  west: -161,
+  south: 18,
+  east: -154,
+  north: 23,
+};
+
+const inBoundingBox = (lat, lng, bbox) => {
+  return lat >= bbox.south && lat <= bbox.north && lng >= bbox.west && lng <= bbox.east;
+};
+
+export const ELEVATION_SOURCES = [
+  {
+    id: 'default',
+    labelKey: 'map.standard30m',
+    descriptionKey: 'map.standardDescription',
+    isGlobal: true,
+  },
+  {
+    id: 'none',
+    labelKey: 'map.flatNone',
+    descriptionKey: 'map.flatNoneDescription',
+    isGlobal: true,
+  },
+  {
+    id: 'kron86',
+    labelKey: 'map.kron86Poland',
+    descriptionKey: 'map.kron86Description',
+    isGlobal: false,
+    checkCoverage: (center) => {
+      if (!center) return false;
+      return inBoundingBox(center.lat, center.lng, KRON86_POLAND_BOUNDS);
+    },
+  },
+  {
+    id: 'usgs',
+    labelKey: 'map.usgs1m',
+    descriptionKey: 'map.usgsDescription',
+    isGlobal: false,
+    checkCoverage: (center) => {
+      if (!center) return false;
+      const { lat, lng } = center;
+      return (
+        inBoundingBox(lat, lng, USGS_CONUS_BOUNDS) ||
+        inBoundingBox(lat, lng, USGS_ALASKA_BOUNDS) ||
+        inBoundingBox(lat, lng, USGS_HAWAII_BOUNDS)
+      );
+    },
+  },
+  {
+    id: 'gpxz',
+    labelKey: 'map.gpxzPremium',
+    descriptionKey: 'map.gpxzDescription',
+    isGlobal: true,
+  },
+];

--- a/stores/mainStore.js
+++ b/stores/mainStore.js
@@ -21,6 +21,7 @@ export const useMainStore = defineStore('main', () => {
     persistedCenter = null;
   }
   const center = ref(sanitizeCenter(persistedCenter));
+  const centerStable = ref(sanitizeCenter(persistedCenter));
   const zoom = ref(parseInt(localStorage.getItem('mapng_zoom')) || 13);
   const resolution = ref(parseInt(localStorage.getItem('mapng_resolution')) || 1024);
   const isDarkMode = ref(localStorage.getItem('theme') === 'dark');
@@ -69,8 +70,12 @@ export const useMainStore = defineStore('main', () => {
 
   // --- Actions ---
   function setCenter(newCenter) {
+    center.value = sanitizeCenter(newCenter);
+  }
+
+  function setCenterStable(newCenter) {
     const safeCenter = sanitizeCenter(newCenter);
-    center.value = safeCenter;
+    centerStable.value = safeCenter;
     localStorage.setItem('mapng_center', JSON.stringify(safeCenter));
   }
 
@@ -148,8 +153,10 @@ export const useMainStore = defineStore('main', () => {
     batchCurrentStep,
     showBatchProgress,
     savedBatchState,
+    centerStable,
     // Actions
     setCenter,
+    setCenterStable,
     setZoom,
     setResolution,
     toggleDarkMode,

--- a/stores/mainStore.js
+++ b/stores/mainStore.js
@@ -21,6 +21,7 @@ export const useMainStore = defineStore('main', () => {
     persistedCenter = null;
   }
   const center = ref(sanitizeCenter(persistedCenter));
+  const liveCenter = ref(sanitizeCenter(persistedCenter));
   const centerStable = ref(sanitizeCenter(persistedCenter));
   const zoom = ref(parseInt(localStorage.getItem('mapng_zoom')) || 13);
   const resolution = ref(parseInt(localStorage.getItem('mapng_resolution')) || 1024);
@@ -71,6 +72,10 @@ export const useMainStore = defineStore('main', () => {
   // --- Actions ---
   function setCenter(newCenter) {
     center.value = sanitizeCenter(newCenter);
+  }
+
+  function setLiveCenter(newCenter) {
+    liveCenter.value = sanitizeCenter(newCenter);
   }
 
   function setCenterStable(newCenter) {
@@ -154,8 +159,10 @@ export const useMainStore = defineStore('main', () => {
     showBatchProgress,
     savedBatchState,
     centerStable,
+    liveCenter,
     // Actions
     setCenter,
+    setLiveCenter,
     setCenterStable,
     setZoom,
     setResolution,


### PR DESCRIPTION
Implementation for [Issue #18  ](https://github.com/nikkiluzader/mapng/issues/18)

- Separated center variable into center (used for live map updates such as area selection and batch selection) and stableCenter (used for heavier operations such as elevation data bounds checking, and saving coordinates to LocalStorage)
- Created elevationSources.js to store and handle bounds checking and elevation data source information
- Dynamically render elevation data sources in ControlPanel.vue and BatchControlPanel.vue based off coordinate bounds checking

Passes all test cases