### PR TITLE
fix: terrarium NO_DATA decoder, motorway one-way, road smoother bilinear, CSM shadow detection, OSM timeout

### DIFF
--- a/components/three/CSMLight.vue
+++ b/components/three/CSMLight.vue
@@ -154,19 +154,23 @@ watch(
 const { onBeforeRender } = useLoop();
 
 // Material patching needs a full scene traversal — don't pay for it every
-// frame. Re-patch when the top-level scene graph changes (new terrain/OSM
-// group swapped in) and on a periodic fallback for materials created deeper
+// frame. Re-patch when a top-level scene child is swapped in (terrain/OSM
+// group replaced) and on a periodic fallback for materials recreated deeper
 // in the tree (e.g. the terrain material :key swap).
 let patchFrameCounter = 0;
-let lastSceneChildCount = -1;
-const PATCH_EVERY_N_FRAMES = 30;
+let lastSceneChildRefs = new Set();
+const PATCH_EVERY_N_FRAMES = 15;
 
 onBeforeRender(() => {
   if (!csm.value) return;
   patchFrameCounter += 1;
-  const childCount = scene.value ? scene.value.children.length : 0;
-  if (childCount !== lastSceneChildCount || patchFrameCounter % PATCH_EVERY_N_FRAMES === 0) {
-    lastSceneChildCount = childCount;
+  const children = scene.value ? scene.value.children : [];
+  const childRefsChanged = children.length !== lastSceneChildRefs.size
+    || children.some(c => !lastSceneChildRefs.has(c));
+  if (childRefsChanged || patchFrameCounter % PATCH_EVERY_N_FRAMES === 0) {
+    if (childRefsChanged) {
+      lastSceneChildRefs = new Set(children);
+    }
     patchMaterials();
   }
   csm.value.update();

--- a/services/osm.js
+++ b/services/osm.js
@@ -114,13 +114,9 @@ const clipLineString = (points, bounds) => {
 const buildQuery = (bounds) => {
   const bbox = `${bounds.south},${bounds.west},${bounds.north},${bounds.east}`;
 
-  // Timeout reduced to 30s (more realistic for public mirrors).
-  // Maxsize reduced to 128 MB — 512 MB was triggering server-side rejection.
-  // Query trimmed: removed redundant/rare keys (seamark, tidal, harbour subtypes,
-  // vegetation, crop, orchard, vineyard, material) that overlap with natural/landuse
-  // and add significant response weight with minimal 3D rendering value.
+  // Query timeout, maxsize, and filtered tag set tuned for public Overpass mirrors.
   return `
-[out:json][timeout:15][maxsize:134217728];
+[out:json][timeout:30][maxsize:134217728];
 (
   way["highway"](${bbox});
   way["building"](${bbox});

--- a/services/osmTexture.js
+++ b/services/osmTexture.js
@@ -757,8 +757,7 @@ const getLaneLayout = (tags) => {
     ].includes(highway) && !explicitNoOneway;
   const isOneWay =
     explicitYesOneway ||
-    impliedLinkOneway ||
-    highway === "motorway";
+    impliedLinkOneway;
   const laneCounts = inferLaneCounts(tags, isOneWay, highway);
   const lanesT = laneCounts.lanesTotal;
   const lanesF = laneCounts.lanesForward;

--- a/services/roadSmoother.js
+++ b/services/roadSmoother.js
@@ -86,10 +86,15 @@ function sampleHeight(heightMap, width, height, px, py) {
     const h01 = heightMap[y1 * width + x0];
     const h11 = heightMap[y1 * width + x1];
 
-    // Simple fallback if NO_DATA_VALUE
-    if (h00 === NO_DATA_VALUE || h10 === NO_DATA_VALUE || h01 === NO_DATA_VALUE || h11 === NO_DATA_VALUE) {
-        return h00;
-    }
+    // Average valid corners when some are NO_DATA; fall back to full bilinear
+    // when all four corners are valid.
+    let sum = 0, count = 0;
+    if (h00 !== NO_DATA_VALUE) { sum += h00; count++; }
+    if (h10 !== NO_DATA_VALUE) { sum += h10; count++; }
+    if (h01 !== NO_DATA_VALUE) { sum += h01; count++; }
+    if (h11 !== NO_DATA_VALUE) { sum += h11; count++; }
+    if (count === 0) return NO_DATA_VALUE;
+    if (count < 4) return sum / count;
 
     const dx = cx - x0;
     const dy = cy - y0;

--- a/services/terrain.js
+++ b/services/terrain.js
@@ -120,7 +120,7 @@ const convertHeightMapToMeters = (heightMap, scale) => {
 
 const decodeTerrariumHeight = (r, g, b) => {
   const h = r * 256 + g + b / 256 - 32768;
-  return h <= -32760 ? NO_DATA_VALUE : h;
+  return h === -32768 ? NO_DATA_VALUE : h;
 };
 
 const getSatelliteZoomForProcessingMpp = (processingMetersPerPixel = 1) => {
@@ -464,20 +464,14 @@ let gpxzRateLimitInfo = null;
 // fetchGPXZRaw() calls at once, so without a shared gate the aggregate request
 // rate is (fetchConcurrency × per-tile chunks) — far over the plan's rps and a
 // guaranteed source of 429s. This gate spaces request *starts* globally so the
-// combined rate across every tile stays under the plan limit. It is reserve-
-// then-await (synchronous slot reservation), which is safe because JS is
-// single-threaded — two callers can't interleave between the read and write.
+// combined rate across every tile stays under the plan limit. The reserve-then-
+// await pattern is safe: the read and write of gpxzNextSlotAt happen in the same
+// synchronous block before any yield, so two callers cannot interleave.
 let gpxzNextSlotAt = 0;
 
-/**
- * Wait for the next globally-paced GPXZ request slot. Spacing is derived from
- * the probed plan rps with a small safety margin; falls back to 1 rps until the
- * plan is known.
- */
 const acquireGpxzSlot = async (signal) => {
-  const rps = Math.max(1, Number(gpxzRateLimitInfo?.rps) || 1);
-  // 10% headroom under the advertised rps absorbs timing jitter and the
-  // server's own window accounting, which otherwise still trips occasional 429s.
+  const plan = gpxzRateLimitInfo;
+  const rps = Math.max(1, Number(plan?.rps) || 1);
   const minIntervalMs = Math.ceil(1000 / (rps * 0.9));
   const now = performance.now();
   const startAt = Math.max(now, gpxzNextSlotAt);


### PR DESCRIPTION

- terrain.js: decodeTerrariumHeight: exact sentinel match (-32768 instead of <= -32760)
- osm.js: align Overpass [timeout] with documented 30s
- roadSmoother.js: average valid corners in bilinear sampleHeight instead of returning NO_DATA
- osmTexture.js: remove unconditional motorway one-way; rely on oneway tags and _link suffix
- terrain.js: snapshot gpxzRateLimitInfo in acquireGpxzSlot for robustness
- CSMLight.vue: detect scene child swaps via Set identity, not just count; halve periodic fallback
