### PR TITLE
Use realistic default widths and depths for waterways

### DIFF
--- a/services/exportBeamNGLevel.js
+++ b/services/exportBeamNGLevel.js
@@ -3438,19 +3438,19 @@ function writeSimGroupTree(zip, folderPath, items) {
 }
 
 const WATERWAY_WIDTHS = {
-  river: 26,
-  canal: 14,
-  stream: 8,
-  drain: 4,
-  ditch: 3,
+  river: 20,
+  canal: 12,
+  stream: 3.5,
+  drain: 2.5,
+  ditch: 1.5,
 };
 
 const WATERWAY_DEPTHS = {
-  river: 8,
-  canal: 5,
-  stream: 3,
-  drain: 2,
-  ditch: 1.5,
+  river: 6,
+  canal: 4,
+  stream: 1.2,
+  drain: 1,
+  ditch: 0.6,
 };
 
 
@@ -5276,8 +5276,8 @@ function buildRiverObjects(terrainData, squareSize, biome) {
   return features.map((feature, index) => {
     const geom = simplifyPolyline(feature.geometry, 72);
     const fallbackWidth = WATERWAY_WIDTHS[feature.tags.waterway] ?? 10;
-    const width = Math.max(3, parseNumericWidth(feature.tags.width, fallbackWidth));
-    const depth = Math.max(1.5, WATERWAY_DEPTHS[feature.tags.waterway] ?? Math.max(2, width * 0.25));
+    const width = Math.max(1.5, parseNumericWidth(feature.tags.width, fallbackWidth));
+    const depth = WATERWAY_DEPTHS[feature.tags.waterway] ?? Math.max(0.6, width * 0.15);
     const worldPts = geom.map((pt) => geoToWorldPoint(pt.lat, pt.lng, terrainData, squareSize, 0));
     const heights = smoothHeights(worldPts.map((pt) => pt[2] + 0.9));
     const nodes = worldPts.map((pt, ptIndex) => ([

--- a/services/osmTerrainMaterials.js
+++ b/services/osmTerrainMaterials.js
@@ -446,11 +446,11 @@ const ROAD_STYLE = {
 
 // Linear waterway types → half-width in metres for terrain-layer rasterisation.
 const WATERWAY_STYLE = {
-  river:  { halfWidthM: 12.0 },
+  river:  { halfWidthM: 10.0 },
   canal:  { halfWidthM:  6.0 },
-  stream: { halfWidthM:  2.5 },
-  drain:  { halfWidthM:  2.0 },
-  ditch:  { halfWidthM:  1.5 },
+  stream: { halfWidthM:  1.75 },
+  drain:  { halfWidthM:  1.25 },
+  ditch:  { halfWidthM:  0.75 },
 };
 
 const CONCRETE_LANDUSES = new Set(['commercial', 'industrial', 'retail']);

--- a/services/osmTexture.js
+++ b/services/osmTexture.js
@@ -1580,12 +1580,11 @@ const renderFeaturesToCanvas = (
         ctx.strokeStyle = ctx.fillStyle; // Use same color
 
         // Width adaptivity
-        let w = 1.5; // Stream default
+        let w = 1; // Stream / ditch default
         if (f.tags.width) w = parseFloat(f.tags.width);
-        else if (f.tags.waterway === "river") w = 6;
-        else if (f.tags.waterway === "canal") w = 4;
-        else if (f.tags.waterway === "drain" || f.tags.waterway === "ditch")
-          w = 1;
+        else if (f.tags.waterway === "river") w = 5;
+        else if (f.tags.waterway === "canal") w = 3;
+        else if (f.tags.waterway === "drain") w = 1;
 
         ctx.lineWidth = w * SCALE_FACTOR;
         ctx.stroke();


### PR DESCRIPTION
Scale down river (20m/6m), canal (12m/4m), stream (3.5m/1.2m), drain (2.5m/1m), and ditch (1.5m/0.6m) to match real-world norms. Sync half-widths in terrain material rasterizer and line widths in 2D OSM texture renderer.  Lower minimum width guard so narrow waterways are no longer clamped to 3m.